### PR TITLE
BUG: handle missing revisions

### DIFF
--- a/resource/check
+++ b/resource/check
@@ -11,15 +11,6 @@ def main(file_id, rev_key, credentials, version):
     revs = service.revisions().list(fileId=file_id).execute()['items']
 
     if version is not None:
-        # We need to make sure the requested version exists but we don't need
-        # to save it for anything yet
-        for rev in revs:
-            if rev['id'] == version['id']:
-                break
-        else:
-            raise ValueError('Could not find revision matching version'
-                             f' {version["id"]}')
-
         version = int(version['id'])
         versions = [rev for rev in revs if int(rev['id']) >= version]
         versions = sorted(versions, key=lambda rev: int(rev['id']))


### PR DESCRIPTION
Not all revisions will be returned from the API, so if a lot of changes
occur between checks, we will get an error. Instead, we will assume that
the last version was simply too old, and thus return all revisions
provided by the API.